### PR TITLE
Removed prepending sockets with "unix:"

### DIFF
--- a/fcgiclient.go
+++ b/fcgiclient.go
@@ -123,7 +123,7 @@ func New(h string, args ...interface{}) (fcgi *FCGIClient, err error) {
 		addr := h + ":" + strconv.FormatInt(int64(args[0].(int)), 10)
 		conn, err = net.Dial("tcp", addr)
 	case string:
-		conn, err = net.Dial("unix", addr)
+		conn, err = net.Dial("unix", args[0].(string))
 	default:
 		err = errors.New("fcgi: we only accept int (port) or string (socket) params.")
 	}

--- a/fcgiclient.go
+++ b/fcgiclient.go
@@ -123,7 +123,6 @@ func New(h string, args ...interface{}) (fcgi *FCGIClient, err error) {
 		addr := h + ":" + strconv.FormatInt(int64(args[0].(int)), 10)
 		conn, err = net.Dial("tcp", addr)
 	case string:
-		addr := h + ":" + args[0].(string)
 		conn, err = net.Dial("unix", addr)
 	default:
 		err = errors.New("fcgi: we only accept int (port) or string (socket) params.")


### PR DESCRIPTION
This causes a file not found error as such,
`panic: dial unix unix:/run/php/php7.0-fpm.sock: connect: no such file or directory`
The correct path is `/run/php/php7.0-fpm.sock`
